### PR TITLE
Remove references from code under 'common' to one under 'core'

### DIFF
--- a/common/ledger/blkstorage/fsblkstorage/blockfile_archiver.go
+++ b/common/ledger/blkstorage/fsblkstorage/blockfile_archiver.go
@@ -120,7 +120,7 @@ func (arch *blockfileArchiver) archiveBlockfile(fileNum int, deleteTheFile bool)
 	loggerArchive.Info("Archiving: archiveBlockfile  deleteTheFile=", deleteTheFile)
 
 	// Send the blockfile to the repository
-	if alreadyArchived, err := sendBlockfileToRepo(arch.chainID, fileNum); err != nil && alreadyArchived == false {
+	if alreadyArchived, err := sendBlockfileToRepo(arch.blockfileDir, fileNum); err != nil && alreadyArchived == false {
 		loggerArchive.Error(err)
 		return alreadyArchived, err
 	} else if alreadyArchived == true {

--- a/common/ledger/blkstorage/fsblkstorage/blockfile_helper.go
+++ b/common/ledger/blkstorage/fsblkstorage/blockfile_helper.go
@@ -20,7 +20,7 @@ import (
 // constructCheckpointInfoFromBlockFiles scans the last blockfile (if any) and construct the checkpoint info
 // if the last file contains no block or only a partially written block (potentially because of a crash while writing block to the file),
 // this scans the second last file (if any)
-func constructCheckpointInfoFromBlockFiles(rootDir string) (*checkpointInfo, error) {
+func constructCheckpointInfoFromBlockFiles(rootDir string, archiveConf *ArchiveConf) (*checkpointInfo, error) {
 	logger.Debugf("Retrieving checkpoint info from block files")
 	var lastFileNum int
 	var numBlocksInFile int
@@ -44,7 +44,7 @@ func constructCheckpointInfoFromBlockFiles(rootDir string) (*checkpointInfo, err
 
 	fileInfo := getFileInfoOrPanic(rootDir, lastFileNum)
 	logger.Debugf("Last Block file info: FileName=[%s], FileSize=[%d]", fileInfo.Name(), fileInfo.Size())
-	if lastBlockBytes, endOffsetLastBlock, numBlocksInFile, err = scanForLastCompleteBlock(rootDir, lastFileNum, 0); err != nil {
+	if lastBlockBytes, endOffsetLastBlock, numBlocksInFile, err = scanForLastCompleteBlock(rootDir, lastFileNum, 0, archiveConf); err != nil {
 		logger.Errorf("Error scanning last file [num=%d]: %s", lastFileNum, err)
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func constructCheckpointInfoFromBlockFiles(rootDir string) (*checkpointInfo, err
 		secondLastFileNum := lastFileNum - 1
 		fileInfo := getFileInfoOrPanic(rootDir, secondLastFileNum)
 		logger.Debugf("Second last Block file info: FileName=[%s], FileSize=[%d]", fileInfo.Name(), fileInfo.Size())
-		if lastBlockBytes, _, _, err = scanForLastCompleteBlock(rootDir, secondLastFileNum, 0); err != nil {
+		if lastBlockBytes, _, _, err = scanForLastCompleteBlock(rootDir, secondLastFileNum, 0, archiveConf); err != nil {
 			logger.Errorf("Error scanning second last file [num=%d]: %s", secondLastFileNum, err)
 			return nil, err
 		}

--- a/common/ledger/blkstorage/fsblkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/fsblkstorage/blockfile_mgr.go
@@ -111,13 +111,13 @@ func newBlockfileMgr(id string, conf *Conf, indexConfig *blkstorage.IndexConfig,
 	}
 	if cpInfo == nil {
 		logger.Info(`Getting block information from block storage`)
-		if cpInfo, err = constructCheckpointInfoFromBlockFiles(rootDir); err != nil {
+		if cpInfo, err = constructCheckpointInfoFromBlockFiles(rootDir, conf.archiveConf); err != nil {
 			panic(fmt.Sprintf("Could not build checkpoint info from block files: %s", err))
 		}
 		logger.Debugf("Info constructed by scanning the blocks dir = %s", spew.Sdump(cpInfo))
 	} else {
 		logger.Debug(`Synching block information from block storage (if needed)`)
-		syncCPInfoFromFS(rootDir, cpInfo)
+		syncCPInfoFromFS(rootDir, cpInfo, conf.archiveConf)
 	}
 	err = mgr.saveCurrentInfo(cpInfo, true)
 	if err != nil {
@@ -176,7 +176,7 @@ func newBlockfileMgr(id string, conf *Conf, indexConfig *blkstorage.IndexConfig,
 // the file of where the last block was written.  Also retrieves contains the
 // last block number that was written.  At init
 //checkpointInfo:latestFileChunkSuffixNum=[0], latestFileChunksize=[0], lastBlockNumber=[0]
-func syncCPInfoFromFS(rootDir string, cpInfo *checkpointInfo) {
+func syncCPInfoFromFS(rootDir string, cpInfo *checkpointInfo, archiveConf *ArchiveConf) {
 	logger.Debugf("Starting checkpoint=%s", cpInfo)
 	//Checks if the file suffix of where the last block was written exists
 	filePath := deriveBlockfilePath(rootDir, cpInfo.latestFileChunkSuffixNum)
@@ -194,7 +194,7 @@ func syncCPInfoFromFS(rootDir string, cpInfo *checkpointInfo) {
 	}
 	//Scan the file system to verify that the checkpoint info stored in db is correct
 	_, endOffsetLastBlock, numBlocks, err := scanForLastCompleteBlock(
-		rootDir, cpInfo.latestFileChunkSuffixNum, int64(cpInfo.latestFileChunksize))
+		rootDir, cpInfo.latestFileChunkSuffixNum, int64(cpInfo.latestFileChunksize), archiveConf)
 	if err != nil {
 		panic(fmt.Sprintf("Could not open current file for detecting last block in the file: %s", err))
 	}
@@ -373,7 +373,7 @@ func (mgr *blockfileMgr) syncIndex() error {
 
 	//open a blockstream to the file location that was stored in the index
 	var stream *blockStream
-	if stream, err = newBlockStream(mgr.rootDir, startFileNum, int64(startOffset), endFileNum); err != nil {
+	if stream, err = newBlockStream(mgr.rootDir, startFileNum, int64(startOffset), endFileNum, mgr.conf.archiveConf); err != nil {
 		return err
 	}
 	var blockBytes []byte
@@ -557,7 +557,7 @@ func (mgr *blockfileMgr) fetchTransactionEnvelope(lp *fileLocPointer) (*common.E
 }
 
 func (mgr *blockfileMgr) fetchBlockBytes(lp *fileLocPointer) ([]byte, error) {
-	stream, err := newBlockfileStream(mgr.rootDir, lp.fileSuffixNum, int64(lp.offset))
+	stream, err := newBlockfileStream(mgr.rootDir, lp.fileSuffixNum, int64(lp.offset), mgr.conf.archiveConf)
 	if err != nil {
 		return nil, err
 	}
@@ -611,11 +611,11 @@ func (mgr *blockfileMgr) saveCurrentInfo(i *checkpointInfo, sync bool) error {
 
 // scanForLastCompleteBlock scan a given block file and detects the last offset in the file
 // after which there may lie a block partially written (towards the end of the file in a crash scenario).
-func scanForLastCompleteBlock(rootDir string, fileNum int, startingOffset int64) ([]byte, int64, int, error) {
+func scanForLastCompleteBlock(rootDir string, fileNum int, startingOffset int64, archiveConf *ArchiveConf) ([]byte, int64, int, error) {
 	//scan the passed file number suffix starting from the passed offset to find the last completed block
 	numBlocks := 0
 	var lastBlockBytes []byte
-	blockStream, errOpen := newBlockfileStream(rootDir, fileNum, startingOffset)
+	blockStream, errOpen := newBlockfileStream(rootDir, fileNum, startingOffset, archiveConf)
 	if errOpen != nil {
 		return nil, 0, 0, errOpen
 	}

--- a/common/ledger/blkstorage/fsblkstorage/blocks_itr.go
+++ b/common/ledger/blkstorage/fsblkstorage/blocks_itr.go
@@ -56,7 +56,7 @@ func (itr *blocksItr) initStream() error {
 	if lp, err = itr.mgr.index.getBlockLocByBlockNum(itr.blockNumToRetrieve); err != nil {
 		return err
 	}
-	if itr.stream, err = newBlockStream(itr.mgr.rootDir, lp.fileSuffixNum, int64(lp.offset), -1); err != nil {
+	if itr.stream, err = newBlockStream(itr.mgr.rootDir, lp.fileSuffixNum, int64(lp.offset), -1, itr.mgr.conf.archiveConf); err != nil {
 		return err
 	}
 	return nil

--- a/common/ledger/blkstorage/fsblkstorage/config.go
+++ b/common/ledger/blkstorage/fsblkstorage/config.go
@@ -30,15 +30,21 @@ const (
 type Conf struct {
 	blockStorageDir  string
 	maxBlockfileSize int
+	archiveConf      *ArchiveConf
+}
+
+type ArchiveConf struct {
+	archiveURL string
+	archiveDir string
 }
 
 // NewConf constructs new `Conf`.
 // blockStorageDir is the top level folder under which `FsBlockStore` manages its data
-func NewConf(blockStorageDir string, maxBlockfileSize int) *Conf {
+func NewConf(blockStorageDir string, maxBlockfileSize int, blockArchiveURL string, blockArchiveDir string) *Conf {
 	if maxBlockfileSize <= 0 {
 		maxBlockfileSize = defaultMaxBlockfileSize
 	}
-	return &Conf{blockStorageDir, maxBlockfileSize}
+	return &Conf{blockStorageDir, maxBlockfileSize, &ArchiveConf{blockArchiveURL, blockArchiveDir}}
 }
 
 func (conf *Conf) getIndexDir() string {

--- a/common/ledger/blkstorage/fsblkstorage/fs_blockstore_archive.go
+++ b/common/ledger/blkstorage/fsblkstorage/fs_blockstore_archive.go
@@ -18,13 +18,11 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/hyperledger/fabric/common/ledger/blockarchive"
-	"github.com/hyperledger/fabric/core/ledger/ledgerconfig"
 )
 
 // sendBlockfileToRepo - Moves a blockfile into the repository via ssh
-func sendBlockfileToRepo(cid string, fileNum int) (bool, error) {
+func sendBlockfileToRepo(blockfileDir string, fileNum int) (bool, error) {
 
-	blockfileDir := filepath.Join(ledgerconfig.GetBlockStorePath(), ChainsDir, cid)
 	srcFilePath := deriveBlockfilePath(blockfileDir, fileNum)
 	srcFile, err := os.Open(srcFilePath)
 	if err != nil {

--- a/common/ledger/blockledger/file/factory.go
+++ b/common/ledger/blockledger/file/factory.go
@@ -66,10 +66,10 @@ func (flf *fileLedgerFactory) Close() {
 }
 
 // New creates a new ledger factory
-func New(directory string) blockledger.Factory {
+func New(directory string, archiveURL string, archiveDir string) blockledger.Factory {
 	return &fileLedgerFactory{
 		blkstorageProvider: fsblkstorage.NewProvider(
-			fsblkstorage.NewConf(directory, -1),
+			fsblkstorage.NewConf(directory, -1, archiveURL, archiveDir),
 			&blkstorage.IndexConfig{
 				AttrsToIndex: []blkstorage.IndexableAttr{blkstorage.IndexableAttrBlockNum}},
 		),

--- a/core/ledger/ledgerstorage/store.go
+++ b/core/ledger/ledgerstorage/store.go
@@ -49,7 +49,12 @@ func NewProvider() *Provider {
 	}
 	indexConfig := &blkstorage.IndexConfig{AttrsToIndex: attrsToIndex}
 	blockStoreProvider := fsblkstorage.NewProvider(
-		fsblkstorage.NewConf(ledgerconfig.GetBlockStorePath(), ledgerconfig.GetMaxBlockfileSize()),
+		fsblkstorage.NewConf(
+			ledgerconfig.GetBlockStorePath(),
+			ledgerconfig.GetMaxBlockfileSize(),
+			ledgerconfig.GetBlockArchiverURL(),
+			ledgerconfig.GetBlockArchiverDir(),
+		),
 		indexConfig)
 
 	pvtStoreProvider := pvtdatastorage.NewProvider()


### PR DESCRIPTION
Reference from code under common directory to code under core directory is not good practice on the existing fabric codebase. To follow the existing architect, these kind of code reference should be removed from our code changes. 

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>