### PR TITLE
Fix issue of state info message including archived block height

### DIFF
--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -737,7 +737,6 @@ func (s *GossipStateProviderImpl) maxAvailableLedgerHeight() uint64 {
 			logger.Debug("Peer", p.PreferredEndpoint(), "doesn't have properties, skipping it")
 			continue
 		}
-		logger.Info("archive: ArchivedBlockHeight", p.Properties.ArchivedBlockHeight)
 		peerHeight := p.Properties.LedgerHeight
 		if max < peerHeight {
 			max = peerHeight


### PR DESCRIPTION
Archived block height in state property can be overriden by mistake

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

Archived block height stored in state property can be overwritten with the previous status info message stored in state info store by mistake

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
